### PR TITLE
Use reflection for obtain the schema from resource when it isn't found in mappings

### DIFF
--- a/src/Factories/Factory.php
+++ b/src/Factories/Factory.php
@@ -19,6 +19,7 @@
 namespace CloudCreativity\JsonApi\Factories;
 
 use CloudCreativity\JsonApi\Encoder\Encoder;
+use CloudCreativity\JsonApi\Schema\Container;
 use Neomerx\JsonApi\Contracts\Schema\ContainerInterface;
 use Neomerx\JsonApi\Encoder\EncoderOptions;
 use Neomerx\JsonApi\Factories\Factory as BaseFactory;
@@ -42,5 +43,17 @@ class Factory extends BaseFactory
         $encoder->setLogger($this->logger);
 
         return $encoder;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createContainer(array $providers = [])
+    {
+        $container = new Container($this, $providers);
+
+        $container->setLogger($this->logger);
+
+        return $container;
     }
 }

--- a/src/Schema/Container.php
+++ b/src/Schema/Container.php
@@ -1,0 +1,49 @@
+<?php namespace CloudCreativity\JsonApi\Schema;
+
+use \InvalidArgumentException;
+use \Neomerx\JsonApi\I18n\Translator as T;
+use Neomerx\JsonApi\Schema\Container as BaseContainer;
+use ReflectionClass;
+
+/**
+ * @package CloudCreativity\JsonApi
+ */
+class Container extends BaseContainer
+{
+    const JSON_API_SCHEMA = 'JSON_API_SCHEMA';
+
+    /**
+     * @inheritdoc
+     */
+    public function getSchemaByType($type)
+    {
+        is_string($type) === true ?: Exceptions::throwInvalidArgument('type', $type);
+
+        if ($this->hasCreatedProvider($type) === true) {
+            return $this->getCreatedProvider($type);
+        }
+
+        // If it does not exist try register using reflection
+        if ($this->hasProviderMapping($type) === false) {
+            $schema = (new ReflectionClass($type))->getConstant(static::JSON_API_SCHEMA);
+            if (! $schema) {
+                throw new InvalidArgumentException(T::t('Schema is not registered for type \'%s\'.', [$type]));
+            }
+            $this->setProviderMapping($type, $schema);
+        }
+
+        $classNameOrClosure = $this->getProviderMapping($type);
+        if ($classNameOrClosure instanceof Closure) {
+            $schema = $this->createSchemaFromClosure($classNameOrClosure);
+        } else {
+            $schema = $this->createSchemaFromClassName($classNameOrClosure);
+        }
+        $this->setCreatedProvider($type, $schema);
+
+        /** @var SchemaProviderInterface $schema */
+
+        $this->setResourceToJsonTypeMapping($schema->getResourceType(), $type);
+
+        return $schema;
+    }
+}


### PR DESCRIPTION
This implementation allow define a constant in entity in order to use reflection feature. Example:

```
<?php namespace App\Models;

use App\JsonApi\Examples\Schema;

class Example {
    const JSON_API_SCHEMA = Schema::class;

    ...
}
```